### PR TITLE
move react from dependencies to devDependencies to fix duplicate react error

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "fast-deep-equal": "3.1.3",
-    "react": "^16.8.0",
     "tslib": "^2.3.0"
   },
   "devDependencies": {
@@ -87,6 +86,7 @@
     "prettier": "^2.3.2",
     "prettier-eslint": "^13.0.0",
     "prettier-eslint-cli": "^5.0.1",
+    "react": "^16.8.0",
     "react-dom": "~16.13.0",
     "react-github-btn": "^1.2.0",
     "serve": "^12.0.0",


### PR DESCRIPTION
## Overview

My project uses React v17, but the version of React in react-channel-plugin is v16, so I got [duplicate react error](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react).

![スクリーンショット 2022-04-12 15 18 36](https://user-images.githubusercontent.com/12913947/162896500-f51a7bf6-9780-45ca-99c7-46f68ffc2ff4.png)

`npm ls react`:

![スクリーンショット 2022-04-12 15 42 27](https://user-images.githubusercontent.com/12913947/162897236-b13ec375-7ecf-4427-8450-6ba9323b67cb.png)

This is due to the inclusion of react in dependencies.
I think moving it to devDependencies will solve this issue.

## Reproduce

https://codesandbox.io/s/react-channel-plugin-44-0y8wd9

---

Thanks for building this great react library 🥇 